### PR TITLE
Snack: hide how-to-pay on search input

### DIFF
--- a/web/src/components/Cart.tsx
+++ b/web/src/components/Cart.tsx
@@ -2,11 +2,11 @@ import { useCartContext } from "../CartProvider";
 import { Button } from "./ui/button";
 import { usePayWithVipps } from "../utils/vipps";
 
-export const Cart = () => {
+export const Cart = ({ showWhenEmpty }: { showWhenEmpty?: boolean }) => {
   const { total, amountOfItemsInCart, productsInCart } = useCartContext();
   const { pay } = usePayWithVipps();
 
-  if (amountOfItemsInCart <= 0) {
+  if (amountOfItemsInCart <= 0 && !showWhenEmpty) {
     return null;
   }
 
@@ -19,7 +19,7 @@ export const Cart = () => {
         Pay with Vipps
       </Button>
 
-      <p className="w-20 text-right text-lg font-semibold">kr {total}</p>
+      {amountOfItemsInCart > 0 && <p className="w-20 text-right text-lg font-semibold">kr {total}</p>}
     </div>
   );
 };

--- a/web/src/components/Snack.tsx
+++ b/web/src/components/Snack.tsx
@@ -49,7 +49,7 @@ export const Snack = () => {
       <Products products={productsToDisplay} />
       <RequestLink />
       <div className={cn(amountOfItemsInCart ? "py-12" : "py-6")} />
-      <Cart />
+      <Cart showWhenEmpty={!!search} />
     </>
   );
 };

--- a/web/src/components/Snack.tsx
+++ b/web/src/components/Snack.tsx
@@ -45,7 +45,7 @@ export const Snack = () => {
         setSelectedCategoryId={setSelectedCategoryId}
       />
       <div className="py-16" />
-      <HowToPay total={total} productsInCart={productsInCart} />
+      {!search && <HowToPay total={total} productsInCart={productsInCart} />}
       <Products products={productsToDisplay} />
       <RequestLink />
       <div className={cn(amountOfItemsInCart ? "py-12" : "py-6")} />


### PR DESCRIPTION
I have a small screen, and want to _not_ have to close keyboard to select a product

| before | after |
| ------ | ----- |
| ![DevTools Nexus 5X](https://github.com/user-attachments/assets/26e2f42b-06b4-4fa5-b55a-94e4036b2ee6) | ![DevTools Nexus 5X (2)](https://github.com/user-attachments/assets/cd45321f-7531-45f2-95ca-e1df9c555a4c) |

I tried to keep the pay-button visible, but it kind of barely won't work on tiny screen.

<img alt="DevTools Nexus 5X" src="https://github.com/user-attachments/assets/ae2d3d62-2c93-4656-9a8f-61276d6924ab" width=400 />


This is obviously meh for those who just want to vipps manually, so I kept the Cart visible if search has input, even without any items added to it.

<img alt="DevTools Nexus 5X (4)" src="https://github.com/user-attachments/assets/132fd7f1-fcc8-41fa-aa72-041c37e76ed3" width=400 />





